### PR TITLE
CTECH-1903: Pins version of sdks < 2.

### DIFF
--- a/src/Lusid.Instruments.Examples/Lusid.Instruments.Examples.csproj
+++ b/src/Lusid.Instruments.Examples/Lusid.Instruments.Examples.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Castle.Core" Version="4.4.0" />
-      <PackageReference Include="Lusid.Sdk.Preview" Version="0.11.4630" />
+      <PackageReference Include="Lusid.Sdk.Preview" Version="(*,2)" />
       <PackageReference Include="LusidFeatures" Version="0.1.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
       <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Signed-off-by: Paul Saunders <paul.saunders@finbourne.com>

# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

Upcoming changes to the the generator for the sdk's might break compatibility. This pins the version of the finbourne sdks so that this package will not break in such an event.

The premise previously had been that pinning to <= 1.0 would still allow us to update patch versions 1.0.x however that is not true, so now pinning < 2
