### PR TITLE
ANA-1775: Migrate to Valuation PV keys

### DIFF
--- a/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
@@ -239,7 +239,7 @@ namespace Lusid.Instruments.Examples.Instruments
             Assert.That(upsertCmdResponse.Failed, Is.Empty);
 
             // CREATE a inline valuation request with an example CDS instrument
-            var pvKey = "Holding/default/PV";
+            var pvKey = "Valuation/PV";
             var valRequest = new InlineValuationRequest(
                 recipeId: new ResourceId(testScope, recipeName),
                 metrics: new List<AggregateSpec>

--- a/src/Lusid.Instruments.Examples/Portfolio/Valuation.cs
+++ b/src/Lusid.Instruments.Examples/Portfolio/Valuation.cs
@@ -364,7 +364,7 @@ namespace Lusid.Instruments.Examples.Portfolio
 
             // DEFINE the response we want
             const string valuationDateKey = "Analytic/default/ValuationDate";
-            const string pvKey = "Holding/default/PV";
+            const string pvKey = "Valuation/PV";
             var valuationSpec = new List<AggregateSpec>
             {
                 new AggregateSpec(valuationDateKey, AggregateSpec.OpEnum.Value),


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- ~~[ ] Raised the PR against the `develop` branch~~ (there is no develop branch)


# Description of the PR

The `Holding/default/PV` address key for valuations is deprecated. This PR swaps it for the recommended `Valuation` domain key.
