### PR TITLE
ANA-1754: update inline valuation calls to include report currency

### DIFF
--- a/src/Lusid.Instruments.Examples/Instruments/BondExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/BondExamples.cs
@@ -184,7 +184,7 @@ namespace Lusid.Instruments.Examples.Instruments
         {
             // CREATE a Bond to be priced by LUSID
             var bond = isZeroCouponBond ? InstrumentExamples.CreateExampleZeroCouponBond() : InstrumentExamples.CreateExampleBond();
-            CallLusidInlineValuationEndpoint(bond, modelName);
+            CallLusidInlineValuationEndpoint(bond, modelName, bond.DomCcy);
         }
 
         [TestCase(ModelSelection.ModelEnum.ConstantTimeValueOfMoney,false)]

--- a/src/Lusid.Instruments.Examples/Instruments/ContractForDifferencesExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/ContractForDifferencesExamples.cs
@@ -109,7 +109,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void CfdInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var cfd = InstrumentExamples.CreateExampleCfd();
-            CallLusidInlineValuationEndpoint(cfd, model);
+            CallLusidInlineValuationEndpoint(cfd, model, cfd.UnderlyingCcy);
         }
 
         [TestCase(ModelSelection.ModelEnum.Discounting)]

--- a/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
@@ -161,7 +161,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void CreditDefaultSwapInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var cds = InstrumentExamples.CreateExampleCreditDefaultSwap();
-            CallLusidInlineValuationEndpoint(cds, model);
+            CallLusidInlineValuationEndpoint(cds, model, cds.FlowConventions.Currency);
         }
 
         [LusidFeature("F22-31")]

--- a/src/Lusid.Instruments.Examples/Instruments/EquityOptionExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/EquityOptionExamples.cs
@@ -167,7 +167,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void EquityOptionInlineValuationExample(ModelSelection.ModelEnum model, bool isCashSettled)
         {
             var equityOption = InstrumentExamples.CreateExampleEquityOption(isCashSettled);
-            CallLusidInlineValuationEndpoint(equityOption, model);
+            CallLusidInlineValuationEndpoint(equityOption, model, equityOption.DomCcy);
         }
 
         [LusidFeature("F22-30")]
@@ -464,7 +464,8 @@ namespace Lusid.Instruments.Examples.Instruments
                 metrics: requestedKeys,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
+                instruments: instruments,
+                reportCurrency:instrument.DomCcy);
 
             // CALL LUSID's inline GetValuationOfWeightedInstruments endpoint
             var result = _aggregationApi.GetValuationOfWeightedInstruments(inlineValuationRequest);

--- a/src/Lusid.Instruments.Examples/Instruments/EquitySwapExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/EquitySwapExamples.cs
@@ -161,7 +161,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void EquitySwapInlineValuationExample(ModelSelection.ModelEnum model, bool multiCoupon)
         {
             var equitySwap = InstrumentExamples.CreateExampleEquitySwap(multiCoupon);
-            CallLusidInlineValuationEndpoint(equitySwap, model);
+            CallLusidInlineValuationEndpoint(equitySwap, model, equitySwap.EquityFlowConventions.Currency);
         }
 
         [LusidFeature("F22-42")]

--- a/src/Lusid.Instruments.Examples/Instruments/FxForwardExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/FxForwardExamples.cs
@@ -109,7 +109,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void FxForwardInlineValuationExample(ModelSelection.ModelEnum model, bool isNdf)
         {
             var fxForward = InstrumentExamples.CreateExampleFxForward(isNdf);
-            CallLusidInlineValuationEndpoint(fxForward, model);
+            CallLusidInlineValuationEndpoint(fxForward, model, fxForward.DomCcy);
         }
         
         [LusidFeature("F22-17")]

--- a/src/Lusid.Instruments.Examples/Instruments/FxOptionExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/FxOptionExamples.cs
@@ -136,7 +136,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void FxOptionInlineValuationExample(ModelSelection.ModelEnum model, bool isDeliveryNotCash)
         {
             var fxOption = InstrumentExamples.CreateExampleFxOption(isDeliveryNotCash);
-            CallLusidInlineValuationEndpoint(fxOption, model);
+            CallLusidInlineValuationEndpoint(fxOption, model, fxOption.DomCcy);
         }
 
         [LusidFeature("F22-21")]

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapRfRExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapRfRExamples.cs
@@ -162,15 +162,15 @@ namespace Lusid.Instruments.Examples.Instruments
         }
        
         [LusidFeature("F22-47")]
-        [TestCase(InstrumentExamples.InterestRateSwapType.SOFR)]
-        [TestCase(InstrumentExamples.InterestRateSwapType.ESTR)]
-        [TestCase(InstrumentExamples.InterestRateSwapType.SONIA)]
-        [TestCase(InstrumentExamples.InterestRateSwapType.TONA)]
-        [TestCase(InstrumentExamples.InterestRateSwapType.SARON)]
-        public void InterestRateSwapRfRInlineValuationExample(InstrumentExamples.InterestRateSwapType rfr)
+        [TestCase(InstrumentExamples.InterestRateSwapType.SOFR, "USD")]
+        [TestCase(InstrumentExamples.InterestRateSwapType.ESTR, "EUR")]
+        [TestCase(InstrumentExamples.InterestRateSwapType.SONIA, "GBP")]
+        [TestCase(InstrumentExamples.InterestRateSwapType.TONA, "JPY")]
+        [TestCase(InstrumentExamples.InterestRateSwapType.SARON, "CHF")]
+        public void InterestRateSwapRfRInlineValuationExample(InstrumentExamples.InterestRateSwapType rfr, string ccy)
         {
             var irs = InstrumentExamples.CreateExampleInterestRateSwap(rfr);
-            CallLusidInlineValuationEndpoint(irs, ModelSelection.ModelEnum.Discounting);
+            CallLusidInlineValuationEndpoint(irs, ModelSelection.ModelEnum.Discounting, ccy);
         }
         
         [LusidFeature("F22-48")]

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapVanillaExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapVanillaExamples.cs
@@ -205,7 +205,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void InterestRateSwapInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var irs = InstrumentExamples.CreateExampleInterestRateSwap(InstrumentExamples.InterestRateSwapType.Vanilla);
-            CallLusidInlineValuationEndpoint(irs, model);
+            CallLusidInlineValuationEndpoint(irs, model, "USD");
         }
 
         [LusidFeature("F22-49")]
@@ -214,7 +214,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void InterestRateSwapCDORInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var irs = InstrumentExamples.CreateExampleInterestRateSwap(InstrumentExamples.InterestRateSwapType.CDOR);
-            CallLusidInlineValuationEndpoint(irs, model);
+            CallLusidInlineValuationEndpoint(irs, model, "CAD");
         }
 
         [LusidFeature("F22-24")]

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapVariantExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapVariantExamples.cs
@@ -177,7 +177,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void InterestRateSwapInlineValuationExample(InstrumentExamples.InterestRateSwapType interestRateSwapType)
         {
             var irs = InstrumentExamples.CreateExampleInterestRateSwap(interestRateSwapType);
-            CallLusidInlineValuationEndpoint(irs, ModelSelection.ModelEnum.Discounting);
+            CallLusidInlineValuationEndpoint(irs, ModelSelection.ModelEnum.Discounting, "USD");
         }
 
         [LusidFeature("F22-54")]

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapWithNamedConventionsExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwapWithNamedConventionsExamples.cs
@@ -163,7 +163,7 @@ namespace Lusid.Instruments.Examples.Instruments
         {
             var irs = InstrumentExamples.CreateSwapByNamedConventions();
             UpsertNamedConventionsToLusid();
-            CallLusidInlineValuationEndpoint(irs, model);
+            CallLusidInlineValuationEndpoint(irs, model, "USD");
         }
 
         [LusidFeature("F22-38")]

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwaptionExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwaptionExamples.cs
@@ -137,7 +137,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void InterestRateSwaptionInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var swaption = InstrumentExamples.CreateExampleInterestRateSwaption();
-            CallLusidInlineValuationEndpoint(swaption, model);
+            CallLusidInlineValuationEndpoint(swaption, model, "USD");
         }
 
         /// <summary>

--- a/src/Lusid.Instruments.Examples/Instruments/InterestRateSwaptionWithNamedConventionsExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/InterestRateSwaptionWithNamedConventionsExamples.cs
@@ -140,7 +140,7 @@ namespace Lusid.Instruments.Examples.Instruments
         {
             var swaption = InstrumentExamples.CreateExampleInterestRateSwaptionWithNamedConventions();
             UpsertNamedConventionsToLusid();
-            CallLusidInlineValuationEndpoint(swaption, model);
+            CallLusidInlineValuationEndpoint(swaption, model, "USD");
         }
 
         private void UpsertNamedConventionsToLusid()

--- a/src/Lusid.Instruments.Examples/Instruments/TermDepositExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/TermDepositExamples.cs
@@ -108,7 +108,7 @@ namespace Lusid.Instruments.Examples.Instruments
         public void TermDepositInlineValuationExample(ModelSelection.ModelEnum model)
         {
             var termDeposit = InstrumentExamples.CreateExampleTermDeposit(TestDataUtilities.EffectiveAt);
-            CallLusidInlineValuationEndpoint(termDeposit, model);
+            CallLusidInlineValuationEndpoint(termDeposit, model, termDeposit.FlowConvention.Currency);
         }
 
         [LusidFeature("F22-34")]

--- a/src/Lusid.Instruments.Examples/MarketData/MarketDataRules.cs
+++ b/src/Lusid.Instruments.Examples/MarketData/MarketDataRules.cs
@@ -95,7 +95,8 @@ namespace Lusid.Sdk.Tests.Tutorials.MarketData
                     new ResourceId(recipeScope, recipeName),
                     valuationSchedule: new ValuationSchedule(effectiveAt: testNow.ToString("o")),
                     metrics: TestDataUtilities.ValuationSpec,
-                    instruments: new List<WeightedInstrument> {new WeightedInstrument(1m, "myOption", instrument)}
+                    instruments: new List<WeightedInstrument> {new WeightedInstrument(1m, "myOption", instrument)},
+                    reportCurrency:"USD"
                 );
 
                 // GET aggregation results

--- a/src/Lusid.Instruments.Examples/Portfolio/Valuation.cs
+++ b/src/Lusid.Instruments.Examples/Portfolio/Valuation.cs
@@ -123,9 +123,10 @@ namespace Lusid.Instruments.Examples.Portfolio
         public void InlineMultiDateValuationOfABond()
         {
             // CREATE a bond instrument inline
+            var bond = InstrumentExamples.CreateExampleBond();
             var instruments = new List<WeightedInstrument>
             {
-                new WeightedInstrument(1, "bond", InstrumentExamples.CreateExampleBond())
+                new WeightedInstrument(1, "bond", bond)
             };
 
             // CREATE inline valuation request asking for instruments PV using a "default" recipe
@@ -136,7 +137,9 @@ namespace Lusid.Instruments.Examples.Portfolio
                 metrics: TestDataUtilities.ValuationSpec,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
+                instruments: instruments,
+                reportCurrency:bond.DomCcy
+                );
 
             // Values the bond for each day in between 2020-02-16 and 2020-02-23 (inclusive)
             var valuation = _apiFactory.Api<IAggregationApi>().GetValuationOfWeightedInstruments(inlineValuationRequest);
@@ -186,8 +189,9 @@ namespace Lusid.Instruments.Examples.Portfolio
                 metrics: TestDataUtilities.ValuationSpec,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
-
+                instruments: instruments,
+                reportCurrency: "USD"
+            );
             // CALL valuation and check the PVs makes sense.
             var valuation = _apiFactory.Api<IAggregationApi>().GetValuationOfWeightedInstruments(inlineValuationRequest);
             Assert.That(valuation, Is.Not.Null);
@@ -247,14 +251,18 @@ namespace Lusid.Instruments.Examples.Portfolio
                 metrics: TestDataUtilities.ValuationSpec,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
+                instruments: instruments,
+                reportCurrency:"USD"
+                );
 
             var constantTimeValueOfMoneyValuationRequest = new InlineValuationRequest(
                 recipeId: new ResourceId(scope, constantTimeValueOfMoneyRecipeCode),
                 metrics: TestDataUtilities.ValuationSpec,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
+                instruments: instruments,
+                reportCurrency:"USD"
+                );
 
             // CALL valuation for Fx-Forward with each recipe
             var discountingValuation = _apiFactory.Api<IAggregationApi>()

--- a/src/Lusid.Instruments.Examples/Utilities/DemoInstrumentBase.cs
+++ b/src/Lusid.Instruments.Examples/Utilities/DemoInstrumentBase.cs
@@ -182,7 +182,7 @@ namespace Lusid.Instruments.Examples.Utilities
         /// In particular, the instrument is also not persisted into any portfolio nor database, it gets deleted at the end.
         /// This endpoint makes it easy to experiment with pricing with less overhead.
         /// </summary>
-        internal void CallLusidInlineValuationEndpoint(LusidInstrument instrument, ModelSelection.ModelEnum model)
+        internal void CallLusidInlineValuationEndpoint(LusidInstrument instrument, ModelSelection.ModelEnum model, string reportCurrency)
         {
             var scope = Guid.NewGuid().ToString();
 
@@ -202,7 +202,8 @@ namespace Lusid.Instruments.Examples.Utilities
                 metrics: TestDataUtilities.ValuationSpec,
                 sort: new List<OrderBySpec> {new OrderBySpec(TestDataUtilities.ValuationDateKey, OrderBySpec.SortOrderEnum.Ascending)},
                 valuationSchedule: valuationSchedule,
-                instruments: instruments);
+                instruments: instruments,
+                reportCurrency: reportCurrency);
 
             // CALL LUSID's inline GetValuationOfWeightedInstruments endpoint
             var result = _aggregationApi.GetValuationOfWeightedInstruments(inlineValuationRequest);

--- a/src/Lusid.Instruments.Examples/Utilities/InstrumentExamples.cs
+++ b/src/Lusid.Instruments.Examples/Utilities/InstrumentExamples.cs
@@ -58,7 +58,7 @@ namespace Lusid.Instruments.Examples.Utilities
             };
         }
 
-        internal static LusidInstrument CreateExampleFxForward(bool isNdf = true)
+        internal static FxForward CreateExampleFxForward(bool isNdf = true)
             => new FxForward(
                 domAmount: 1m,
                 fgnAmount: -123m,
@@ -72,7 +72,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 instrumentType: LusidInstrument.InstrumentTypeEnum.FxForward
             );
 
-        internal static LusidInstrument CreateExampleForwardRateAgreement()
+        internal static ForwardRateAgreement CreateExampleForwardRateAgreement()
         {
             return new ForwardRateAgreement(
                 startDate: TestDataUtilities.StartDate,
@@ -96,7 +96,7 @@ namespace Lusid.Instruments.Examples.Utilities
             DoubleNotouch
         };
 
-        internal static LusidInstrument CreateExampleFxOption(
+        internal static FxOption CreateExampleFxOption(
             bool isDeliveryNotCash = true,
             string example = "VanillaEuropean"
         )
@@ -274,7 +274,7 @@ namespace Lusid.Instruments.Examples.Utilities
             throw new ArgumentException($"FxOption example '{example}' is not found. Possible examples are: [{allExamples}]");
         }
 
-        internal static LusidInstrument CreateExampleEquityOption(bool isCashSettled = false)
+        internal static EquityOption CreateExampleEquityOption(bool isCashSettled = false)
             => new EquityOption(
                 startDate: TestDataUtilities.StartDate,
                 optionMaturityDate: TestDataUtilities.StartDate.AddYears(1),
@@ -290,7 +290,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 instrumentType: LusidInstrument.InstrumentTypeEnum.EquityOption
             );
 
-        internal static LusidInstrument CreateExampleSimpleInstrument()
+        internal static SimpleInstrument CreateExampleSimpleInstrument()
             => new SimpleInstrument(
                 instrumentType: LusidInstrument.InstrumentTypeEnum.SimpleInstrument,
                 domCcy: "USD",
@@ -298,7 +298,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 simpleInstrumentType: "Equity"
             );
 
-        internal static LusidInstrument CreateExampleEquity()
+        internal static Equity CreateExampleEquity()
             => new Equity(
                 instrumentType: LusidInstrument.InstrumentTypeEnum.Equity,
                 domCcy: "USD",
@@ -316,7 +316,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 settleDays: settleDays,
                 resetDays: resetDays);
 
-        internal static LusidInstrument CreateExampleBond()
+        internal static Bond CreateExampleBond()
             => new Bond(
                 startDate: TestDataUtilities.StartDate,
                 maturityDate: TestDataUtilities.StartDate.AddYears(6),
@@ -328,7 +328,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 instrumentType: LusidInstrument.InstrumentTypeEnum.Bond
             );
 
-        internal static LusidInstrument CreateExampleCfd()
+        internal static ContractForDifference CreateExampleCfd()
             => new ContractForDifference(
                 startDate: TestDataUtilities.StartDate,
                 maturityDate: TestDataUtilities.StartDate.AddYears(6),
@@ -342,7 +342,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 instrumentType: LusidInstrument.InstrumentTypeEnum.ContractForDifference
             );
 
-        internal static LusidInstrument CreateExampleZeroCouponBond()
+        internal static Bond CreateExampleZeroCouponBond()
             => new Bond(
                 startDate: TestDataUtilities.StartDate,
                 maturityDate: TestDataUtilities.StartDate.AddYears(6),
@@ -718,7 +718,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 settleDays: 0,
                 resetDays: 0);
 
-        internal static LusidInstrument CreateExampleCreditDefaultSwap()
+        internal static CreditDefaultSwap CreateExampleCreditDefaultSwap()
             => new CreditDefaultSwap(
                 ticker: "XYZCorp",
                 startDate: TestDataUtilities.StartDate,
@@ -735,7 +735,7 @@ namespace Lusid.Instruments.Examples.Utilities
                 instrumentType: LusidInstrument.InstrumentTypeEnum.CreditDefaultSwap
             );
 
-        internal static LusidInstrument CreateExampleTermDeposit(DateTimeOffset startDate)
+        internal static TermDeposit CreateExampleTermDeposit(DateTimeOffset startDate)
             => new TermDeposit(
                 startDate: TestDataUtilities.StartDate,
                 maturityDate: TestDataUtilities.StartDate.AddYears(1),

--- a/src/Lusid.Instruments.Examples/Utilities/TutorialBase.cs
+++ b/src/Lusid.Instruments.Examples/Utilities/TutorialBase.cs
@@ -44,7 +44,7 @@ namespace Lusid.Instruments.Examples.Utilities
         
         internal void ValidateUpsertInstrumentResponse(UpsertInstrumentsResponse response)
         {
-            Assert.That(response.Failed.Count, Is.EqualTo(0));
+            Assert.That(response.Failed, Is.Empty);
             Assert.That(response.Values.Count, Is.EqualTo(1));
         }
         


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [~] Raised the PR against the `develop` branch

# Description of the PR

Adding report currency to all calls to inline valuation that are requesting the key `Valuation/PvInReportCcy` to match up with changes tightening the validation and consistency around that currency specific key.
