### PR TITLE
ANA-3068: Removing null params that have been removed due to removal of ConfigurationRecipeSnippet

### DIFF
--- a/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/CreditDefaultSwapExamples.cs
@@ -207,7 +207,7 @@ namespace Lusid.Instruments.Examples.Instruments
             );
 
             // UPSERT the configuration recipe
-            var upsertRecipeRequest = new UpsertRecipeRequest(recipe, null);
+            var upsertRecipeRequest = new UpsertRecipeRequest(recipe);
             var upsertRecipeResponse = _recipeApi.UpsertConfigurationRecipe(upsertRecipeRequest);
             Assert.That(upsertRecipeResponse.Value, Is.Not.Null);
 

--- a/src/Lusid.Instruments.Examples/Portfolio/StructuredResultStore.cs
+++ b/src/Lusid.Instruments.Examples/Portfolio/StructuredResultStore.cs
@@ -104,7 +104,7 @@ namespace Lusid.Instruments.Examples.Portfolio
 
             // Create and upsert the recipe
             var configurationRecipe = new ConfigurationRecipe(scope, portfolioCode, new MarketContext(), pricingContext);
-            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe, null);
+            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe);
             _recipeApi.UpsertConfigurationRecipe(upsertRecipeRequest);
 
 
@@ -254,7 +254,7 @@ namespace Lusid.Instruments.Examples.Portfolio
             var pricingOptions = new PricingOptions {AllowAnyInstrumentsWithSecUidToPriceOffLookup = false, AllowPartiallySuccessfulEvaluation = true};
             var pricingContext = new PricingContext(null, null, pricingOptions, new List<ResultKeyRule>{resultDataKeyRule} );
             var configurationRecipe = new ConfigurationRecipe(documentScope, "recipe", new MarketContext(), pricingContext);
-            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe, null);
+            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe);
             _recipeApi.UpsertConfigurationRecipe(upsertRecipeRequest);
 
             // Creating a valuation request, in which we request portfolio id, YtD, and some user key.
@@ -494,7 +494,7 @@ namespace Lusid.Instruments.Examples.Portfolio
             var pricingOptions = new PricingOptions {AllowAnyInstrumentsWithSecUidToPriceOffLookup = false, AllowPartiallySuccessfulEvaluation = true};
             var pricingContext = new PricingContext(null, null, pricingOptions, new List<ResultKeyRule>{resultDataKeyRule} );
             var configurationRecipe = new ConfigurationRecipe(documentScope, "recipe", new MarketContext(), pricingContext);
-            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe, null);
+            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe);
             _recipeApi.UpsertConfigurationRecipe(upsertRecipeRequest);
 
             // Create a valuation request, requesting multiple results including Strategy and Country.
@@ -678,7 +678,7 @@ namespace Lusid.Instruments.Examples.Portfolio
             var pricingOptions = new PricingOptions {AllowAnyInstrumentsWithSecUidToPriceOffLookup = false, AllowPartiallySuccessfulEvaluation = true};
             var pricingContext = new PricingContext(null, null, pricingOptions, new List<ResultKeyRule>{resultDataKeyRule} );
             var configurationRecipe = new ConfigurationRecipe(documentScope, "recipe", new MarketContext(), pricingContext);
-            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe, null);
+            var upsertRecipeRequest = new UpsertRecipeRequest(configurationRecipe);
             _recipeApi.UpsertConfigurationRecipe(upsertRecipeRequest);
 
             // Create a valuation request, requesting LusidInstrument Id, Pv amount and UserDefinedData


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass

# Description of the PR

After removing ConfigurationRecipeSnippet, the UpsertRecipeRequest now takes one argument to reflect this I removed all the "nulls" being passed into the UpsertRecipeRequest, no test behaviour was affected here.
