### PR TITLE
ANA-4788: Updating option settlement date to be optional in EquityOpt…

### DIFF
--- a/src/Lusid.Instruments.Examples/Instruments/EquityOptionExamples.cs
+++ b/src/Lusid.Instruments.Examples/Instruments/EquityOptionExamples.cs
@@ -208,7 +208,7 @@ namespace Lusid.Instruments.Examples.Instruments
 
             // CREATE wide enough window to pick up all cashflows associated to the EquityOption
             var windowStart = equityOption.StartDate.AddMonths(-1);
-            var windowEnd = equityOption.OptionSettlementDate.AddMonths(1);
+            var windowEnd = equityOption.OptionSettlementDate?.AddMonths(1);
 
             // CREATE portfolio and add instrument to the portfolio
             var scope = Guid.NewGuid().ToString();
@@ -257,7 +257,7 @@ namespace Lusid.Instruments.Examples.Instruments
                 equityOption.DomCcy);
             TestDataUtilities.CheckNonZeroPvBeforeMaturityAndZeroAfter(
                 valuationBeforeAndAfterExpirationEquityOption,
-                equityOption.OptionSettlementDate);
+                equityOption.OptionSettlementDate.Value);
 
             // UPSERT the cashflows back into LUSID. We first populate the cashflow transactions with unique IDs.
             var upsertCashFlowTransactions = PortfolioCashFlows.PopulateCashFlowTransactionWithUniqueIds(
@@ -364,7 +364,7 @@ namespace Lusid.Instruments.Examples.Instruments
 
             // CREATE wide enough window to pick up all cashflows associated to the EquityOption
             var windowStart = equityOption.StartDate.AddMonths(-1);
-            var windowEnd = equityOption.OptionSettlementDate.AddMonths(1);
+            var windowEnd = equityOption.OptionSettlementDate?.AddMonths(1);
 
             // CREATE portfolio and add instrument to the portfolio
             var scope = Guid.NewGuid().ToString();
@@ -413,7 +413,7 @@ namespace Lusid.Instruments.Examples.Instruments
                 equityOption.DomCcy);
             TestDataUtilities.CheckNonZeroPvBeforeMaturityAndZeroAfter(
                 valuationBeforeAndAfterExpirationEquityOption,
-                equityOption.OptionSettlementDate);
+                equityOption.OptionSettlementDate.Value);
 
             // UPSERT the cashflows back into LUSID. We first populate the cashflow transactions with unique IDs.
             var upsertCashFlowTransactions = PortfolioCashFlows.PopulateCashFlowTransactionWithUniqueIds(


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR
This fixes build issues with EquityOptionExamples.cs, due to recent LUSID SDK changes making Option Settlement Date optional for Equity Options.